### PR TITLE
New tests for showLoser, showWinner and showRanking methods

### DIFF
--- a/DiceGame/tests/Feature/GameController_ShowLoserTest.php
+++ b/DiceGame/tests/Feature/GameController_ShowLoserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Laravel\Passport\Passport;
+
+class GameController_ShowLoser extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_admin_can_get_worst_player()
+    {
+        // Create a "admin" user and give them the "admin" permission
+        Passport::actingAs(User::factory()->create(), ['admin']);
+
+        // Fetch the best player
+        $response = $this->get(route('admin.showWinner'));
+
+        // Check for a 200 status code
+        $response->assertStatus(200);
+
+        // Check JSON response structure
+        $response->assertJsonStructure([
+            'message',
+        ]);
+    }
+
+    public function test_admin_cannot_see_worst_player_without_admin_permission()
+    {
+        // Create a "player" user and give them the "player" permission
+        Passport::actingAs(User::factory()->create(), ['player']);
+
+        // Fetch the best player
+        $response = $this->get(route('admin.showWinner'));
+
+        // Check for a 403 status code
+        $response->assertStatus(403);
+
+        // Check JSON response structure
+        $response->assertJsonStructure([
+            'error',
+        ]);
+    }
+}

--- a/DiceGame/tests/Feature/GameController_ShowRankingTest.php
+++ b/DiceGame/tests/Feature/GameController_ShowRankingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use App\Models\User;
+use Laravel\Passport\Passport;
+
+class GameController_ShowRankingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_admin_can_get_ranking()
+    {
+        // Create a "admin" user and give them the "admin" permission
+        Passport::actingAs(User::factory()->create(), ['admin']);
+
+        // Fetch the best player
+        $response = $this->get(route('admin.showWinner'));
+
+        // Check for a 200 status code
+        $response->assertStatus(200);
+
+        // Check JSON response structure
+        $response->assertJsonStructure([
+            'message',
+        ]);
+    }
+
+    public function test_admin_cannot_see_ranking()
+    {
+        // Create a "player" user and give them the "player" permission
+        Passport::actingAs(User::factory()->create(), ['player']);
+
+        // Fetch the best player
+        $response = $this->get(route('admin.showWinner'));
+
+        // Check for a 403 status code
+        $response->assertStatus(403);
+
+        // Check JSON response structure
+        $response->assertJsonStructure([
+            'error',
+        ]);
+    }
+}

--- a/DiceGame/tests/Feature/GameController_ShowWinnerTest.php
+++ b/DiceGame/tests/Feature/GameController_ShowWinnerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use App\Models\User;
+use Laravel\Passport\Passport;
+
+class GameController_ShowWinnerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_admin_can_get_best_player()
+    {
+        // Create a "admin" user and give them the "admin" permission
+        Passport::actingAs(User::factory()->create(), ['admin']);
+
+        // Fetch the best player
+        $response = $this->get(route('admin.showWinner'));
+
+        // Check for a 200 status code
+        $response->assertStatus(200);
+
+        // Check JSON response structure
+        $response->assertJsonStructure([
+            'message',
+        ]);
+    }
+
+    public function test_admin_cannot_see_best_player_without_admin_permission()
+    {
+        // Create a "player" user and give them the "player" permission
+        Passport::actingAs(User::factory()->create(), ['player']);
+
+        // Fetch the best player
+        $response = $this->get(route('admin.showWinner'));
+
+        // Check for a 403 status code
+        $response->assertStatus(403);
+
+        // Check JSON response structure
+        $response->assertJsonStructure([
+            'error',
+        ]);
+    }
+}


### PR DESCRIPTION
PR# 10 Feature/TestingAdminRoutes

Created test for admin routes checking if gets 200 or 403 responses. All of them are working well 
- GameController_ShowWinnerTest
	- test_admin_can_get_best_player()
	- test_admin_cannot_see_best_player_without_admin_permission()
- GameController_ShowLoserTest
	- test_admin_can_get_worst_player()
	- test_admin_cannot_see_worst_player_without_admin_permission()
- GameController_ShowRankingTest
	- test_admin_can_get_ranking()
	- test_admin_cannot_see_ranking()